### PR TITLE
Add support for exploded .less stylesheets

### DIFF
--- a/src/main/java/com/orange/wro/taglib/config/WroConfig.java
+++ b/src/main/java/com/orange/wro/taglib/config/WroConfig.java
@@ -42,12 +42,14 @@ import ro.isdc.wro.model.resource.ResourceType;
  */
 public class WroConfig {
 	private static final String WRO_BASE_URL_ATTRIBUTE = "com.orange.wro.base.url";
+	private static final String LESS_SCRIPT_ATTRIBUTE = "com.orange.wro.less.path";
 
 	private static WroConfig instance;
 
 	private Map<String, FilesGroup> groups;
 	private ServletContext servletContext;
 	private boolean initialized = false;
+	private String lessPath;
 
 	public static WroConfig getInstance() throws ConfigurationException {
 		if (instance == null) {
@@ -126,6 +128,13 @@ public class WroConfig {
 			instance = new WroConfig();
 			instance.servletContext = context;
 		}
+	}
+
+	public String getLessPath() {
+		if (lessPath == null) {
+			lessPath = servletContext.getInitParameter(LESS_SCRIPT_ATTRIBUTE);
+		}
+		return lessPath;
 	}
 
 	public FilesGroup getGroup(String groupName) {

--- a/src/main/java/com/orange/wro/taglib/tag/AsJsArrayIncludeTag.java
+++ b/src/main/java/com/orange/wro/taglib/tag/AsJsArrayIncludeTag.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import ro.isdc.wro.model.resource.ResourceType;
 
 public class AsJsArrayIncludeTag extends IncludeTag {
-	private final static String markupFormat = "'%s',";
 	private ResourceType groupType;
 
 	public void setGroupType(String groupType) {
@@ -32,8 +31,8 @@ public class AsJsArrayIncludeTag extends IncludeTag {
 		return groupType;
 	}
 
-	protected String getMarkupFormat() {
-		return markupFormat;
+	protected String getMarkupFormat(String src) {
+		return WroTagLibConstants.JS_ARRAY_MARKUP;
 	}
 
 	@Override

--- a/src/main/java/com/orange/wro/taglib/tag/IncludeTag.java
+++ b/src/main/java/com/orange/wro/taglib/tag/IncludeTag.java
@@ -131,6 +131,12 @@ public abstract class IncludeTag extends SimpleTagSupport {
 
 		for (String fileName : files) {
 			writeLink(builder, fileName);
+			
+			if (fileName.endsWith(".less")) {
+				getJspContext().setAttribute(WroTagLibConstants.LESS_INJECTED,
+						true);
+			
+			}
 		}
 	}
 
@@ -146,10 +152,14 @@ public abstract class IncludeTag extends SimpleTagSupport {
 	}
 
 	private void writeLink(StringBuilder builder, String src) {
+		writeLink(builder, src, getMarkupFormat(src));
+	}
+	
+	private void writeLink(StringBuilder builder, String src, String markup) {
 		PageContext context = (PageContext) getJspContext();
-		String contextPath = ((HttpServletRequest) context.getRequest())
-				.getContextPath();
-		String link = String.format(getMarkupFormat(), quote(contextPath + src));
+		HttpServletRequest req = (HttpServletRequest) context.getRequest();
+		String path = req.getContextPath() + src;
+		String link = String.format(markup, quote(path));
 		builder.append(link);
 
 		if (pretty) {
@@ -160,7 +170,7 @@ public abstract class IncludeTag extends SimpleTagSupport {
 	/**
 	 * @return the markup format to generate the markup from the file name.
 	 */
-	protected abstract String getMarkupFormat();
+	protected abstract String getMarkupFormat(String src);
 
 	/**
 	 * @return the resource type for this tag

--- a/src/main/java/com/orange/wro/taglib/tag/OptionalScriptTag.java
+++ b/src/main/java/com/orange/wro/taglib/tag/OptionalScriptTag.java
@@ -1,0 +1,43 @@
+package com.orange.wro.taglib.tag;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.orange.wro.taglib.config.WroConfig;
+
+public class OptionalScriptTag extends SimpleTagSupport {
+
+	@Override
+	public void doTag() throws JspException, IOException {
+
+		WroConfig conf = WroConfig.getInstance();
+		PageContext context = (PageContext) getJspContext();
+		StringBuilder builder = new StringBuilder();
+		
+		Object lessObj = context.getAttribute(WroTagLibConstants.LESS_INJECTED);
+		boolean isLessNeeded = lessObj == null ? false : (Boolean)lessObj;
+		
+		if (isLessNeeded) {
+			writeScript(context, builder, conf.getLessPath());
+		}
+		
+		context.getOut().append(builder);
+	}
+	
+	private void writeScript(PageContext context, StringBuilder builder,
+			String path) throws IOException {
+		
+		if (!StringUtils.isEmpty(path)) {
+			HttpServletRequest req = (HttpServletRequest) context.getRequest();
+			String fullPath = req.getContextPath() + path;
+			String out = String.format(WroTagLibConstants.JS_MARKUP, fullPath);
+			builder.append(out);
+		}
+	}
+}

--- a/src/main/java/com/orange/wro/taglib/tag/ScriptHtmlIncludeTag.java
+++ b/src/main/java/com/orange/wro/taglib/tag/ScriptHtmlIncludeTag.java
@@ -20,12 +20,11 @@ import ro.isdc.wro.model.resource.ResourceType;
 
 public class ScriptHtmlIncludeTag extends HtmlIncludeTag {
 	private static final ResourceType groupType = ResourceType.JS;
-	private static final String markupFormat = "<script src='%s'></script>";
 	
 	protected ResourceType getGroupType() {
 		return groupType;
 	}
-	protected String getMarkupFormat() {
-		return markupFormat;
+	protected String getMarkupFormat(String src) {
+		return WroTagLibConstants.JS_MARKUP;
 	}
 }

--- a/src/main/java/com/orange/wro/taglib/tag/StyleHtmlIncludeTag.java
+++ b/src/main/java/com/orange/wro/taglib/tag/StyleHtmlIncludeTag.java
@@ -20,13 +20,14 @@ import ro.isdc.wro.model.resource.ResourceType;
 
 public class StyleHtmlIncludeTag extends HtmlIncludeTag {
 	private static final ResourceType groupType = ResourceType.CSS;
-	private static final String markupFormat = "<link rel='stylesheet' href='%s' />";
 	
 	protected ResourceType getGroupType() {
 		return groupType;
 	}
-	protected String getMarkupFormat() {
-		return markupFormat;
+	protected String getMarkupFormat(String src) {
+		if (src == null) return null;
+		return src.endsWith(".less")
+				? WroTagLibConstants.LESS_MARKUP
+				: WroTagLibConstants.CSS_MARKUP;
 	}
-
 }

--- a/src/main/java/com/orange/wro/taglib/tag/WroTagLibConstants.java
+++ b/src/main/java/com/orange/wro/taglib/tag/WroTagLibConstants.java
@@ -1,0 +1,12 @@
+package com.orange.wro.taglib.tag;
+
+public abstract class WroTagLibConstants {
+
+	public static final String LESS_INJECTED = "com.orange.wro.less.injected";
+	
+	public static final String CSS_MARKUP = "<link rel='stylesheet' href='%s' />";
+	public static final String JS_ARRAY_MARKUP = "'%s',";
+	public static final String JS_MARKUP = "<script src='%s' type='text/javascript'></script>";
+	public static final String LESS_MARKUP = "<link rel='stylesheet/less' type='text/css' href='%s' />";
+	
+}

--- a/src/main/resources/META-INF/wro.tld
+++ b/src/main/resources/META-INF/wro.tld
@@ -104,6 +104,9 @@
 			<type>java.lang.String</type>
 		</attribute>
 	</tag>
-
-
+	<tag>
+		<name>optionalScript</name>
+		<tag-class>com.orange.wro.taglib.tag.OptionalScriptTag</tag-class>
+		<body-content>empty</body-content>
+	</tag>
 </taglib>


### PR DESCRIPTION
Basically, include less.js when .less files are included in the page). This inclusion needs 3 steps:
 1) include the .less files as .css, that way Wro4J will handle them
 2) include the tag '<wro:optionalScript />' at the end of the header AFTER the .less
    stylesheets, that's were less.js will be inserted if needed
 3) define the path to 'less.js' in your web.xml using the context parameter
    'com.orange.wro.less.path'
