### PR TITLE
Fixes #5 by adding new properties for JS and CSS output path configuration

### DIFF
--- a/src/main/java/com/orange/wro/taglib/config/WroTagLibConfig.java
+++ b/src/main/java/com/orange/wro/taglib/config/WroTagLibConfig.java
@@ -20,6 +20,7 @@ import ro.isdc.wro.model.WroModel;
 
 import javax.servlet.ServletContext;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,7 +32,10 @@ public class WroTagLibConfig {
 		PROPERTIES_DEFAULT_LOCATION("com.orange.wro.properties.default.location"),
 		PROPERTIES_LOCATION("com.orange.wro.properties.location"),
 		PROPERTIES_FILENAME("com.orange.wro.properties.filename"),
+
 		BASE_URL("com.orange.wro.base.url"),
+		BASE_URL_JS("com.orange.wro.base.url.js"),
+		BASE_URL_CSS("com.orange.wro.base.url.css"),
 		LESS_PATH("com.orange.wro.less.path"),
 		RESOURCE_DOMAIN("com.orange.wro.resource.domain");
 
@@ -59,7 +63,7 @@ public class WroTagLibConfig {
 			this.servletContext.getInitParameter(InitParam.PROPERTIES_FILENAME.getKey())
 		);
 
-		this.configValues =  new HashMap<String, String>(3);
+		this.configValues =  new HashMap<String, String>(InitParam.values().length - 3);
 
 		this.initialize();
 	}
@@ -78,9 +82,17 @@ public class WroTagLibConfig {
 		}
 	}
 
-	public String getBaseUrl() {
-		return this.configValues.get(InitParam.BASE_URL.getKey());
-	}
+    public String getBaseUrl() {
+   		return this.configValues.get(InitParam.BASE_URL.getKey());
+   	}
+
+    public String getBaseUrlJs() {
+   		return this.configValues.get(InitParam.BASE_URL_JS.getKey());
+   	}
+
+    public String getBaseUrlCss() {
+   		return this.configValues.get(InitParam.BASE_URL_CSS.getKey());
+   	}
 
 	public String getLessPath() {
 		return this.configValues.get(InitParam.LESS_PATH.key);
@@ -106,6 +118,26 @@ public class WroTagLibConfig {
 	@SuppressWarnings("unchecked")
 	public Set<String> getResourcePaths() {
 		String wroBaseUrl = this.getBaseUrl();
-		return this.servletContext.getResourcePaths(wroBaseUrl);
+
+        if (wroBaseUrl == null) {
+            String wroBaseUrlJs = this.getBaseUrlJs();
+            String wroBaseUrlCss = this.getBaseUrlCss();
+
+            if ((wroBaseUrlJs == null) || (wroBaseUrlCss == null)) {
+                throw new ConfigurationException("com.orange.wro.base.url was not configured. In this case, " +
+                        "both com.orange.wro.base.url.js and com.orange.wro.base.url.css must be configured.");
+            } else {
+                Set wroBaseUrlJsPaths = this.servletContext.getResourcePaths(wroBaseUrlJs);
+                Set wroBaseUrlCssPaths = this.servletContext.getResourcePaths(wroBaseUrlCss);
+                Set<String> resourcePaths = new HashSet<String>();
+
+                resourcePaths.addAll(wroBaseUrlJsPaths);
+                resourcePaths.addAll(wroBaseUrlCssPaths);
+
+                return resourcePaths;
+            }
+        } else {
+            return this.servletContext.getResourcePaths(wroBaseUrl);
+        }
 	}
 }

--- a/src/test/java/com/orange/wro/taglib/config/WroConfigTestConstants.java
+++ b/src/test/java/com/orange/wro/taglib/config/WroConfigTestConstants.java
@@ -12,10 +12,14 @@ public interface WroConfigTestConstants {
     String DEFAULT_RESOURCE_DOMAIN = "defaultResourceDomain";
 
     String CUSTOM_BASE_URL = "customBaseUrl";
+    String CUSTOM_BASE_URL_JS = "customBaseUrlJs";
+    String CUSTOM_BASE_URL_CSS = "customBaseUrlCss";
     String CUSTOM_LESS_PATH = "customLessPath";
     String CUSTOM_RESOURCE_DOMAIN = "customResourceDomain";
 
     String CLASSPATH_BASE_URL = "classpathBaseUrl";
+    String CLASSPATH_BASE_URL_JS = "classpathBaseUrlJs";
+    String CLASSPATH_BASE_URL_CSS = "classpathBaseUrlCss";
     String CLASSPATH_LESS_PATH = "classpathLessPath";
     String CLASSPATH_RESOURCE_DOMAIN = "classpathResourceDomain";
 }

--- a/src/test/java/com/orange/wro/taglib/config/WroTagLibConfigTest.java
+++ b/src/test/java/com/orange/wro/taglib/config/WroTagLibConfigTest.java
@@ -31,12 +31,7 @@ import javax.servlet.ServletContext;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CLASSPATH_BASE_URL;
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CLASSPATH_LESS_PATH;
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CLASSPATH_RESOURCE_DOMAIN;
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CUSTOM_BASE_URL;
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CUSTOM_LESS_PATH;
-import static com.orange.wro.taglib.config.WroConfigTestConstants.CUSTOM_RESOURCE_DOMAIN;
+import static com.orange.wro.taglib.config.WroConfigTestConstants.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,8 +48,14 @@ public class WroTagLibConfigTest {
 	public void setUp() {
 		this.servletContext = mock(ServletContext.class);
 
-		when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
-			thenReturn(CUSTOM_BASE_URL);
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
+      			thenReturn(CUSTOM_BASE_URL);
+
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_JS.getKey())).
+      			thenReturn(CUSTOM_BASE_URL_JS);
+
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_CSS.getKey())).
+      			thenReturn(CUSTOM_BASE_URL_CSS);
 
 		when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.LESS_PATH.getKey())).
 			thenReturn(CUSTOM_LESS_PATH);
@@ -68,6 +69,8 @@ public class WroTagLibConfigTest {
 		WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
 
 		assertEquals("Should be custom base url", CUSTOM_BASE_URL, wroTagLibConfig.getBaseUrl());
+		assertEquals("Should be custom base url for JS", CUSTOM_BASE_URL_JS, wroTagLibConfig.getBaseUrlJs());
+		assertEquals("Should be custom base url for CSS", CUSTOM_BASE_URL_CSS, wroTagLibConfig.getBaseUrlCss());
 		assertEquals("Should be custom Less path", CUSTOM_LESS_PATH, wroTagLibConfig.getLessPath());
 		assertEquals("Should be custom resource domain", CUSTOM_RESOURCE_DOMAIN, wroTagLibConfig.getResourceDomain());
 	}
@@ -80,6 +83,8 @@ public class WroTagLibConfigTest {
 		WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
 
 		assertEquals("Should be classpath base url", CLASSPATH_BASE_URL, wroTagLibConfig.getBaseUrl());
+		assertEquals("Should be classpath base url for JS", CLASSPATH_BASE_URL_JS, wroTagLibConfig.getBaseUrlJs());
+		assertEquals("Should be classpath base url for CSS", CLASSPATH_BASE_URL_CSS, wroTagLibConfig.getBaseUrlCss());
 		assertEquals("Should be classpath Less path", CLASSPATH_LESS_PATH, wroTagLibConfig.getLessPath());
 		assertEquals("Should be classpath resource domain", CLASSPATH_RESOURCE_DOMAIN, wroTagLibConfig.getResourceDomain());
 	}
@@ -104,17 +109,79 @@ public class WroTagLibConfigTest {
 		assertEquals("Should return the available model", modelFromTest, modelFromConfig);
 	}
 
-	@Test
-	public void resourcePathsAreRetrievedFromTheBaseUrl() {
-		WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
+    @Test
+   	public void resourcePathsAreRetrievedFromTheBaseUrl() {
+   		WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
 
-		Set<String> testResourcePaths = new HashSet<String>();
-		testResourcePaths.add("testResourcePath1");
+   		Set<String> testResourcePaths = new HashSet<String>();
+   		testResourcePaths.add("testResourcePath1");
 
-		when(this.servletContext.getResourcePaths(CUSTOM_BASE_URL)).thenReturn(testResourcePaths);
+   		when(this.servletContext.getResourcePaths(CUSTOM_BASE_URL)).thenReturn(testResourcePaths);
 
-		assertEquals("Resource paths should be based on the base URL",
-			testResourcePaths, wroTagLibConfig.getResourcePaths()
-		);
-	}
+   		assertEquals("Resource paths should be based on the base URL",
+   			testResourcePaths, wroTagLibConfig.getResourcePaths()
+   		);
+   	}
+
+    @Test(expected = ConfigurationException.class)
+    public void whenNoBaseUrlIsAvailableExecutionStops() {
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
+      			thenReturn(null);
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_JS.getKey())).
+      			thenReturn(null);
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_CSS.getKey())).
+      			thenReturn(null);
+
+        WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
+        wroTagLibConfig.getResourcePaths();
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void whenOnlyJSBaseUrlIsAvailableExecutionStops() {
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
+      			thenReturn(null);
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_JS.getKey())).
+      			thenReturn(null);
+
+        WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
+        wroTagLibConfig.getResourcePaths();
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void whenOnlyCSSBaseUrlIsAvailableExecutionStops() {
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
+      			thenReturn(null);
+        when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL_CSS.getKey())).
+      			thenReturn(null);
+
+        WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
+        wroTagLibConfig.getResourcePaths();
+    }
+
+
+    @Test
+   	public void resourcePathsAreRetrievedFromTheJSAndCSSUrlsWhenBaseUrlIsNotAvailable() {
+           when(this.servletContext.getInitParameter(WroTagLibConfig.InitParam.BASE_URL.getKey())).
+         			thenReturn(null);
+
+   		WroTagLibConfig wroTagLibConfig = new WroTagLibConfig(this.servletContext);
+
+        Set<String> testResourcePathsJs = new HashSet<String>();
+      		testResourcePathsJs.add("testResourcePathJS1");
+
+        Set<String> testResourcePathsCss = new HashSet<String>();
+      		testResourcePathsCss.add("testResourcePathCSS1");
+
+        Set<String> testResourcePaths = new HashSet<String>();
+        testResourcePaths.addAll(testResourcePathsJs);
+        testResourcePaths.addAll(testResourcePathsCss);
+
+
+   		when(this.servletContext.getResourcePaths(CUSTOM_BASE_URL_JS)).thenReturn(testResourcePathsJs);
+   		when(this.servletContext.getResourcePaths(CUSTOM_BASE_URL_CSS)).thenReturn(testResourcePathsCss);
+
+   		assertEquals("Resource paths should be based on the base URL",
+   			testResourcePaths, wroTagLibConfig.getResourcePaths()
+   		);
+   	}
 }

--- a/src/test/resources/wro4j-taglib-test.properties
+++ b/src/test/resources/wro4j-taglib-test.properties
@@ -1,3 +1,5 @@
 com.orange.wro.base.url=classpathBaseUrl
+com.orange.wro.base.url.js=classpathBaseUrlJs
+com.orange.wro.base.url.css=classpathBaseUrlCss
 com.orange.wro.less.path=classpathLessPath
 com.orange.wro.resource.domain=classpathResourceDomain


### PR DESCRIPTION
Pretty self explanatory. Since the `<jsDestinationFolder/>` and `<cssDestinationFolder/>` paths are used by the Maven plugin, there's no way for the tag library to retrieve them automagically. Thus, all I could think of was adding two new properties (as suggested by @simoami).
