### PR TITLE
Handle correctly if multiple versioned file presents

### DIFF
--- a/src/main/java/com/orange/wro/taglib/config/GroupLoader.java
+++ b/src/main/java/com/orange/wro/taglib/config/GroupLoader.java
@@ -71,7 +71,10 @@ public class GroupLoader implements IGroupLoader {
 				} else {
 					if (FilenameUtils.getBaseName(path).startsWith(groupName)) {
 						String type = FilenameUtils.getExtension(path);
-						res.put(ResourceType.get(type), path);
+						// if the result already contains a path for this type, then it won't be overridden
+						if (!res.containsKey(ResourceType.get(type))) {
+							res.put(ResourceType.get(type), path);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When using filename strategy like CRC versioning, then with incremental build it could happen that multiple files presents for the same group with different version. In these situations, the GroupLoader sometimes results random versions of the file instead of resulting the exact file defined by the mapping file.
I've corrected that the mapping file overrides the result if the group presents in it. If not, than one of the versions will be resulted.
